### PR TITLE
removed prepack script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "main": "./bundles/ngx-sherlock.umd.js",
   "typings": "./ngx-sherlock.d.ts",
   "scripts": {
-    "prepack": "npm run build",
     "test": "node ./tasks/test",
     "build": "npm run test && node ./tasks/build && shx mv dist/@politie dist/politie",
     "g": "node ./node_modules/angular-librarian",


### PR DESCRIPTION
we should not have this in the main package.json as users should never run pack or publish from main directory. Those are handled by separate scripts that publish from the `dist` directory