### PR TITLE
Wouter/ready for publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,58 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/politie/ngx-sherlock.svg)](https://greenkeeper.io/)
 
+**NgxSherlock** is a set of Angular bindings for the [Sherlock](https://github.com/politie/sherlock)
+ reactive state management library.
+
 ## Usage
+
+### Installation
+
+Install **NgxSherlock** by running:
+
+```bash
+$ npm install @politie/ngx-sherlock
+```
+
+Add the `NgxSherlockModule` to your `AppModule`:
+
+```typescript
+import { NgModule } from '@angular/core';
+import { NgxSherlockModule } from '@politie/ngx-sherlock';
+
+@NgModule({
+    imports: [NgxSherlockModule],
+    ...
+})
+export class AppModule { }
+```
+
+### `ValuePipe`
+
+The `ValuePipe` unwraps a `Derivable` or `DerivableProxy` value and triggers the `ChangeDetectorRef` whenever an internal value changes and a change detection cycle is needed.
+
+#### Example
+
+`my.component.html`:
+```html
+<h1>My awesome counter</h1>
+<p>We're already at: <strong>{{counter$ | value}}</strong></p>
+```
+
+`my.component.ts`:
+```typescript
+import { Component, OnInit } from '@angular/core';
+import { Atom, atom } from '@politie/sherlock';
+
+@Component({
+    selector: 'my-component';
+    templateUrl: 'my.component.html',
+})
+export class MyComponent implements OnInit {
+    readonly counter$: Atom<number> = atom(0);
+
+    ngOnInit() {
+        setInterval(() => counter$.swap(i => i++), 1000);
+    }
+}
+```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@politie/ngx-sherlock",
   "version": "1.0.0-beta.0",
   "description": "ngx-sherlock is an Angular tooling library to be used with the @politie/sherlock distributed reactive state management library.",
-  "private": true,
+  "private": false,
   "main": "./bundles/ngx-sherlock.umd.js",
   "typings": "./ngx-sherlock.d.ts",
   "scripts": {
@@ -22,6 +22,9 @@
     "type": "git",
     "url": "https://github.com/politie/ngx-sherlock"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "angular",
     "sherlock",
@@ -35,7 +38,7 @@
     "Merijn van der Linden <njirem@gmail.com>",
     "Wouter Spaak <w.spaak@gmail.com>"
   ],
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/politie/sherlock/issues"
   },


### PR DESCRIPTION
This PR makes sure the library can be published to NPM.

Publishing is done (manually) from master, by running `npm run tagVersion`. This will let you choose which version type to publish, automatically tags the commit in master and publish to NPM.