### PR TITLE
Wouter/auto change detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,59 @@ import { NgxSherlockModule } from '@politie/ngx-sherlock';
 export class AppModule { }
 ```
 
+### `autoDetectChanges`
+
+**Signature**:
+```typescript
+autoDetectChanges(detectorRef: ChangeDetectorRef): void;
+```
+
+The function `autoDetectChanges` will automatically run a change detection cycle when `Derivables` or `DerivableProxies` within a component's template change internal state. The function should be called in an `OnInit` lifecycle hook of a component or directive.
+
+The `autoDetectChanges` function guarantees model and view fidelity, meaning one can easily use Angular's forms and template functionality.
+
+#### Example
+
+`trusty-sidekick.component.html`:
+```html
+<h2>Well there you are, {{sidekick$.firstname.$value}} {{sidekick$.surname.$value}}!</h2>
+<input type="text" [(ngModel)]="sidekick$.firstname.$value" placeholder="First name">
+<input type="text" [(ngModel)]="sidekick$.surname.$value" placeholder="Surname">
+```
+
+`trusty-sidekick.component.ts`:
+```typescript
+import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { autoDetectChanges } from '@politie/ngx-sherlock';
+import { atom } from '@politie/sherlock';
+import { ProxyDescriptor } from '@politie/sherlock-proxy';
+
+@Component({
+    selector: 'trusty-sidekick',
+    templateUrl: 'trusty-sidekick.component.html',
+    changeDetection: ChangeDetectionStrategy.onPush,
+})
+export class TrustySidekickComponent implements OnInit {
+
+    private readonly sidekickAtom$ = atom({ firstname: 'John', surname: 'Watson' });
+    readonly sidekick$ = new ProxyDescriptor().$create(this.sidekick$);
+
+    constructor(private readonly cdr: ChangeDetectorRef) { }
+
+    ngOnInit() {
+        // Calling autoDetectChanges here will keep the template up-to-date with the state.
+        autoDetectChanges(this.cdr);
+    }
+}
+```
+
+---
+
 ### `ValuePipe`
 
-The `ValuePipe` unwraps a `Derivable` or `DerivableProxy` value and triggers the `ChangeDetectorRef` whenever an internal value changes and a change detection cycle is needed.
+The `ValuePipe` unwraps a `Derivable` or `DerivableProxy` value and triggers the `ChangeDetectorRef` whenever an internal value changes
+and a change detection cycle is needed. This allows a component to have an `OnPush` `ChangeDetectionStrategy`, greatly increasing
+performance.
 
 #### Example
 
@@ -42,18 +92,19 @@ The `ValuePipe` unwraps a `Derivable` or `DerivableProxy` value and triggers the
 
 `my.component.ts`:
 ```typescript
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { Atom, atom } from '@politie/sherlock';
 
 @Component({
     selector: 'my-component';
     templateUrl: 'my.component.html',
+    changeDetection: ChangeDetectionStrategy.onPush,
 })
 export class MyComponent implements OnInit {
     readonly counter$: Atom<number> = atom(0);
 
     ngOnInit() {
-        setInterval(() => counter$.swap(i => i++), 1000);
+        setInterval(() => this.counter$.swap(i => i++), 1000);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,4 +2,58 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/politie/ngx-sherlock.svg)](https://greenkeeper.io/)
 
+**NgxSherlock** is a set of Angular bindings for the [Sherlock](https://github.com/politie/sherlock)
+ reactive state management library.
+
 ## Usage
+
+### Installation
+
+Install **NgxSherlock** by running:
+
+```bash
+$ npm install @politie/ngx-sherlock
+```
+
+Add the `NgxSherlockModule` to your `AppModule`:
+
+```typescript
+import { NgModule } from '@angular/core';
+import { NgxSherlockModule } from '@politie/ngx-sherlock';
+
+@NgModule({
+    imports: [NgxSherlockModule],
+    ...
+})
+export class AppModule { }
+```
+
+### `ValuePipe`
+
+The `ValuePipe` unwraps a `Derivable` or `DerivableProxy` value and triggers the `ChangeDetectorRef` whenever an internal value changes and a change detection cycle is needed.
+
+#### Example
+
+`my.component.html`:
+```html
+<h1>My awesome counter</h1>
+<p>We're already at: <strong>{{counter$ | value}}</strong></p>
+```
+
+`my.component.ts`:
+```typescript
+import { Component, OnInit } from '@angular/core';
+import { Atom, atom } from '@politie/sherlock';
+
+@Component({
+    selector: 'my-component';
+    templateUrl: 'my.component.html',
+})
+export class MyComponent implements OnInit {
+    readonly counter$: Atom<number> = atom(0);
+
+    ngOnInit() {
+        setInterval(() => counter$.swap(i => i++), 1000);
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -57,9 +57,7 @@ import { ProxyDescriptor } from '@politie/sherlock-proxy';
     `,
 })
 export class TrustySidekickComponent {
-
-    private readonly sidekickAtom$ = atom({ firstname: 'John', surname: 'Watson' });
-    readonly sidekick$ = new ProxyDescriptor().$create(this.sidekick$);
+    readonly sidekick$ = new ProxyDescriptor().$create(atom({firstname: 'John', surname: 'Watson'}));
 }
 
 @Component({

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
   ],
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/politie/sherlock/issues"
+    "url": "https://github.com/politie/ngx-sherlock/issues"
   },
-  "homepage": "https://github.com/politie/sherlock#readme",
+  "homepage": "https://github.com/politie/ngx-sherlock#readme",
   "devDependencies": {
     "@angular/compiler-cli": "^5.0.2",
     "@politie/sherlock-proxy": "^1.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "np": "^2.12.0",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.3",
-    "rollup": "0.51.7",
+    "rollup": "0.52.0",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "3.0.0",
     "rollup-plugin-sourcemaps": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@politie/ngx-sherlock",
   "version": "1.0.0-beta.0",
   "description": "ngx-sherlock is an Angular tooling library to be used with the @politie/sherlock distributed reactive state management library.",
-  "private": true,
+  "private": false,
   "main": "./bundles/ngx-sherlock.umd.js",
   "typings": "./ngx-sherlock.d.ts",
   "scripts": {
@@ -22,6 +22,9 @@
     "type": "git",
     "url": "https://github.com/politie/ngx-sherlock"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "angular",
     "sherlock",
@@ -35,7 +38,7 @@
     "Merijn van der Linden <njirem@gmail.com>",
     "Wouter Spaak <w.spaak@gmail.com>"
   ],
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/politie/sherlock/issues"
   },

--- a/src/change-detection/auto-detect-changes.spec.ts
+++ b/src/change-detection/auto-detect-changes.spec.ts
@@ -27,6 +27,13 @@ describe('change detection', () => {
             cdr.internal$.set('new value');
             expect(cdr.detectChanges).toHaveBeenCalledTimes(2);
         });
+
+        it('should no longer call cdr#detectChanges when the component has been destroyed', () => {
+            expect(cdr.detectChanges).toHaveBeenCalledTimes(1);
+            cdr.destroy();
+            cdr.internal$.set('other value');
+            expect(cdr.detectChanges).toHaveBeenCalledTimes(1);
+        });
     });
 });
 
@@ -36,4 +43,8 @@ class MockChangeDetectorRef {
 
     detectChanges = jasmine.createSpy('detectChanges').and.callFake(() => this.internal$.get());
     onDestroy = jasmine.createSpy('onDestroy').and.callFake((fn: () => void) => this.destroyer = fn);
+
+    destroy() {
+        this.destroyer();
+    }
 }

--- a/src/change-detection/auto-detect-changes.spec.ts
+++ b/src/change-detection/auto-detect-changes.spec.ts
@@ -1,0 +1,39 @@
+import { ChangeDetectorRef } from '@angular/core';
+import { atom } from '@politie/sherlock';
+import { autoDetectChanges } from './auto-detect-changes';
+
+describe('change detection', () => {
+    describe('autoDetectChanges', () => {
+        let cdr: MockChangeDetectorRef;
+
+        beforeEach(() => {
+            cdr = new MockChangeDetectorRef();
+            autoDetectChanges(cdr as any);
+        });
+
+        it('should throw when an invalid ChangeDetectorRef is passed', () => {
+            expect(() => autoDetectChanges({} as any)).toThrowError('autoDetectChanges was not called with a valid ChangeDetectorRef.');
+        });
+
+        it('should call cdr#onDestroy with a destroyer function', () => {
+            expect(typeof cdr.destroyer).toEqual('function');
+            expect((cdr.internal$ as any).observers.length).toEqual(1);
+            cdr.destroyer();
+            expect((cdr.internal$ as any).observers.length).toEqual(0);
+        });
+
+        it('should call cdr#detectChanges when any internal derivable state changes', () => {
+            expect(cdr.detectChanges).toHaveBeenCalledTimes(1);
+            cdr.internal$.set('new value');
+            expect(cdr.detectChanges).toHaveBeenCalledTimes(2);
+        });
+    });
+});
+
+class MockChangeDetectorRef {
+    readonly internal$ = atom('value');
+    destroyer: () => void;
+
+    detectChanges = jasmine.createSpy('detectChanges').and.callFake(() => this.internal$.get());
+    onDestroy = jasmine.createSpy('onDestroy').and.callFake((fn: () => void) => this.destroyer = fn);
+}

--- a/src/change-detection/auto-detect-changes.spec.ts
+++ b/src/change-detection/auto-detect-changes.spec.ts
@@ -1,50 +1,143 @@
-import { ChangeDetectorRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { atom } from '@politie/sherlock';
+import { ProxyDescriptor } from '@politie/sherlock-proxy';
 import { autoDetectChanges } from './auto-detect-changes';
 
 describe('change detection', () => {
     describe('autoDetectChanges', () => {
-        let cdr: MockChangeDetectorRef;
+        let fixture: ComponentFixture<TestCpt>;
+        let component: TestCpt;
+        let detectChangesSpy: jasmine.Spy;
+        let onDestroySpy: jasmine.Spy;
 
         beforeEach(() => {
-            cdr = new MockChangeDetectorRef();
-            autoDetectChanges(cdr as any);
+            TestBed.configureTestingModule({ imports: [CommonModule], declarations: [TestCpt] }).compileComponents();
         });
 
-        it('should throw when an invalid ChangeDetectorRef is passed', () => {
-            expect(() => autoDetectChanges({} as any)).toThrowError('autoDetectChanges was not called with a valid ChangeDetectorRef.');
+        beforeEach(() => {
+            fixture = TestBed.createComponent(TestCpt);
+            component = fixture.componentInstance;
+            detectChangesSpy = spyOn(component.cdr, 'detectChanges').and.callThrough();
+            onDestroySpy = spyOn(component.cdr as any, 'onDestroy').and.callThrough();
+
+            fixture.detectChanges();
         });
 
-        it('should call cdr#onDestroy with a destroyer function', () => {
-            expect(typeof cdr.destroyer).toEqual('function');
-            expect((cdr.internal$ as any).observers.length).toEqual(1);
-            cdr.destroyer();
-            expect((cdr.internal$ as any).observers.length).toEqual(0);
+        it('should throw when no ChangeDetectorRef is provided', () => {
+            expect(() => autoDetectChanges({} as any)).toThrowError(`autoDetectChanges was not called with a valid ChangeDetectorRef.`);
         });
 
-        it('should call cdr#detectChanges when any internal derivable state changes', () => {
-            expect(cdr.detectChanges).toHaveBeenCalledTimes(1);
-            cdr.internal$.set('new value');
-            expect(cdr.detectChanges).toHaveBeenCalledTimes(2);
+        it('should have registered a reaction destroying function with the ChangeDetectorRef', () => {
+            expect(onDestroySpy).toHaveBeenCalledTimes(1);
+            // tslint:disable-next-line:ban-types
+            const destroyer: Function = onDestroySpy.calls.mostRecent().args[0];
+            expect(typeof destroyer).toEqual('function');
+            expect(destroyer.name).toEqual('done');
         });
 
-        it('should no longer call cdr#detectChanges when the component has been destroyed', () => {
-            expect(cdr.detectChanges).toHaveBeenCalledTimes(1);
-            cdr.destroy();
-            cdr.internal$.set('other value');
-            expect(cdr.detectChanges).toHaveBeenCalledTimes(1);
+        it('should have called ChangeDetectorRef#detectChanges once on initialization', () => {
+            expect(detectChangesSpy).toHaveBeenCalledTimes(1);
+        });
+
+        describe('using Derivable', () => {
+            // let's reset detectChangesSpy so we start out with zero calls.
+            beforeEach(() => detectChangesSpy.calls.reset());
+
+            it('should correctly render state on initialization', () => {
+                expect(getH1Text(fixture)).toContain(component.state$.get());
+            });
+
+            it('should call ChangeDetectorRef#detectChanges when state changes', () => {
+                component.state$.set('new value');
+                expect(detectChangesSpy).toHaveBeenCalledTimes(1);
+                expect(getH1Text(fixture)).toContain('new value');
+
+                component.state$.set('newer value');
+                expect(detectChangesSpy).toHaveBeenCalledTimes(2);
+                expect(getH1Text(fixture)).toContain('newer value');
+            });
+
+            it('should stop reaction when component gets destroyed', () => {
+                component.state$.set('foo');
+                expect(detectChangesSpy).toHaveBeenCalledTimes(1);
+
+                // Destroy component
+                fixture.destroy();
+
+                component.state$.set('bar');
+                expect(detectChangesSpy).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        describe('using DerivableProxy', () => {
+            // Set component to 'proxy mode' and reset detectChangesSpy call count.
+            beforeEach(() => {
+                component.useProxy$.set(true);
+                detectChangesSpy.calls.reset();
+            });
+
+            it('should correctly render state on initialization', () => {
+                expect(getH1Text(fixture)).toBe(component.state$.derive(v => v.toUpperCase()).get());
+            });
+
+            it('should correctly render when underlying atom changes', () => {
+                component.state$.set('foobar');
+                expect(getH1Text(fixture)).toBe('FOOBAR');
+                expect(detectChangesSpy).toHaveBeenCalledTimes(1);
+            });
+
+            it('should correctly render when $value is set and call ChangeDetectorRef#detectChanges', () => {
+                component.proxyState$.$value = 'Set via $value';
+                expect(getH1Text(fixture)).toBe('SET VIA $VALUE');
+                expect(detectChangesSpy).toHaveBeenCalledTimes(1);
+
+                component.proxyState$.$value = 'new value for $value';
+                expect(getH1Text(fixture)).toBe('NEW VALUE FOR $VALUE');
+                expect(detectChangesSpy).toHaveBeenCalledTimes(2);
+            });
+
+            it('should stop detecting changes when component gets destroyed', () => {
+                component.proxyState$.$value = 'foo';
+                expect(detectChangesSpy).toHaveBeenCalledTimes(1);
+
+                fixture.destroy();
+
+                component.proxyState$.$value = 'bar';
+                expect(detectChangesSpy).toHaveBeenCalledTimes(1);
+            });
         });
     });
 });
 
-class MockChangeDetectorRef {
-    readonly internal$ = atom('value');
-    destroyer: () => void;
+@Component({
+    template: `
+    <h1 *ngIf="!useProxy">{{state}}</h1>
+    <h1 *ngIf="useProxy">{{proxyState$.$value}}</h1>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TestCpt implements OnInit {
+    readonly state$ = atom('my value');
+    readonly proxyState$ = new ProxyDescriptor().$create(this.state$.lens({
+        get: v => v.toUpperCase(),
+        set: v => v.toLowerCase(),
+    }));
 
-    detectChanges = jasmine.createSpy('detectChanges').and.callFake(() => this.internal$.get());
-    onDestroy = jasmine.createSpy('onDestroy').and.callFake((fn: () => void) => this.destroyer = fn);
+    readonly useProxy$ = atom(false);
 
-    destroy() {
-        this.destroyer();
+    get state() { return this.state$.get(); }
+    get useProxy() { return this.useProxy$.get(); }
+
+    constructor(readonly cdr: ChangeDetectorRef) { }
+
+    ngOnInit() {
+        autoDetectChanges(this.cdr);
     }
+}
+
+function getH1Text(fixture: ComponentFixture<TestCpt>): string {
+    return fixture.debugElement.query(By.css('h1')).nativeElement.textContent.trim();
 }

--- a/src/change-detection/auto-detect-changes.ts
+++ b/src/change-detection/auto-detect-changes.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectorRef } from '@angular/core';
+import { derivation } from '@politie/sherlock';
+
+export function autoDetectChanges(detector: ChangeDetectorRef) {
+    if (!hasOnDestroy(detector)) {
+        throw new Error(`autoDetectChanges was not called with a valid ChangeDetectorRef.`);
+    }
+    detector.onDestroy(derivation(() => detector.detectChanges()).react(() => void 0));
+}
+
+function hasOnDestroy(obj: any): obj is { onDestroy(cb: () => void); } {
+    return obj && obj.onDestroy === 'function';
+}

--- a/src/change-detection/auto-detect-changes.ts
+++ b/src/change-detection/auto-detect-changes.ts
@@ -1,6 +1,10 @@
 import { ChangeDetectorRef } from '@angular/core';
 import { derivation } from '@politie/sherlock';
 
+/**
+ * This function automatically detects changes when any `Derivable` or `DerivableProxy` in a consuming template changes state.
+ * @param detector `ChangeDetectorRef` instance passed in by a consuming component.
+ */
 export function autoDetectChanges(detector: ChangeDetectorRef) {
     if (!hasOnDestroy(detector)) {
         throw new Error(`autoDetectChanges was not called with a valid ChangeDetectorRef.`);
@@ -9,5 +13,5 @@ export function autoDetectChanges(detector: ChangeDetectorRef) {
 }
 
 function hasOnDestroy(obj: any): obj is { onDestroy(cb: () => void); } {
-    return obj && obj.onDestroy === 'function';
+    return obj && typeof obj.onDestroy === 'function';
 }

--- a/src/change-detection/index.ts
+++ b/src/change-detection/index.ts
@@ -1,0 +1,1 @@
+export * from './auto-detect-changes';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './ngx-sherlock.module';
 export * from './pipes';
+export * from './change-detection';
 export * from './types';


### PR DESCRIPTION
Function that automatically runs a change detection cycle when a piece of state confined to a component or directive changes.

Fixes [#11](https://github.com/politie/ngx-sherlock/issues/11) and [#12](https://github.com/politie/ngx-sherlock/issues/12).