### PR TITLE
pre-alpha CD workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,15 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x]
+
     steps:
       - uses: actions/checkout@v2
+
       - name: Use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
       - name: Cache node_modules
         id: cache-modules
         uses: actions/cache@v2.1.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,18 +6,20 @@ on:
 
 env:
   NODE_VERSION: 14.x
-  # This is a public_repo Github personal access token.
-  GITHUB_TOKEN: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
 jobs:
   bump-version:
     name: Bump package.json Versions
+    if: ${{ !startsWith(github.event.head_commit.message, '[CI/CD]') }}
     runs-on: ubuntu-latest
     outputs:
       tag-name: ${{ steps.lib-bump.outputs.newTag }}
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          # This is a public_repo Github personal access token.
+          token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
       - name: Bump dev-app version
         id: dev-bump
@@ -39,6 +41,7 @@ jobs:
   github-release:
     name: Release on Github
     needs: bump-version
+    if: startsWith(needs.bump-version.outputs.tag-name, 'v')
     runs-on: ubuntu-latest
 
     steps:
@@ -54,6 +57,7 @@ jobs:
   npm-release:
     name: Release on NPM
     needs: bump-version
+    if: startsWith(needs.bump-version.outputs.tag-name, 'v')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+env:
+  NODE_VERSION: 14.x
+  # This is a public_repo Github personal access token.
+  GITHUB_TOKEN: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
+
+jobs:
+  bump-version:
+    name: Bump package.json Versions
+    runs-on: ubuntu-latest
+    outputs:
+      tag-name: ${{ steps.lib-bump.outputs.newTag }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Bump dev-app version
+        id: dev-bump
+        uses: phips28/gh-action-bump-version@v9.0.1
+        with:
+          tag-prefix: 'v'
+          skip-tag: true
+          commit-message: '[CI/CD]: bump dev-app to {{version}}'
+
+      - name: Bump lib version
+        id: lib-bump
+        uses: phips28/gh-action-bump-version@v9.0.1
+        with:
+          tag-prefix: 'v'
+          commit-message: '[CI/CD]: bump lib to {{version}}'
+        env:
+          PACKAGEJSON_DIR: projects/politie/ngx-sherlock
+
+  github-release:
+    name: Release on Github
+    needs: bump-version
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.bump-version.outputs.tag-name }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.bump-version.outputs.tag-name }}
+
+  npm-release:
+    name: Release on NPM
+    needs: bump-version
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.bump-version.outputs.tag-name }}
+
+      - name: Use node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Release
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          # This is an automation type NPM access token.
+          token: ${{ secrets.WORKFLOW_NPM_TOKEN }}
+          package: dist/politie/ngx-sherlock/package.json


### PR DESCRIPTION
Implements a CD workflow which triggers on each push to the main branch, which bumps the package version (see https://github.com/phips28/gh-action-bump-version for wording), and releases to Github and NPM.