### PR TITLE
feat(value-for.pipe): add new ValueForPipe for @for loops

### DIFF
--- a/projects/politie/ngx-sherlock/src/lib/value-for.pipe.spec.ts
+++ b/projects/politie/ngx-sherlock/src/lib/value-for.pipe.spec.ts
@@ -1,43 +1,43 @@
-import { ChangeDetectorRef } from "@angular/core";
-import { atom, DerivableAtom } from "@politie/sherlock";
-import { ProxyDescriptor } from "@politie/sherlock-proxy";
-import { getObservers } from "./utils.spec";
-import { ValueForPipe } from "./value-for.pipe";
+import { ChangeDetectorRef } from '@angular/core';
+import { atom, DerivableAtom } from '@politie/sherlock';
+import { ProxyDescriptor } from '@politie/sherlock-proxy';
+import { getObservers } from './utils.spec';
+import { ValueForPipe } from './value-for.pipe';
 
-describe("ValueForPipe", () => {
+describe('ValueForPipe', () => {
     let cdr: jasmine.SpyObj<ChangeDetectorRef>;
     let pipe: ValueForPipe<any>;
     let emitter: DerivableAtom<any>;
     let proxy: any;
 
     beforeEach(() => {
-        cdr = jasmine.createSpyObj("ChangeDetectorRef", ["markForCheck"]);
+        cdr = jasmine.createSpyObj('ChangeDetectorRef', ['markForCheck']);
         pipe = new ValueForPipe(cdr);
 
         emitter = atom.unresolved();
         proxy = new ProxyDescriptor().$create(emitter);
     });
 
-    describe("#transform", () => {
-        it("should return undefined for unresolved Derivable", () => {
+    describe('#transform', () => {
+        it('should return undefined for unresolved Derivable', () => {
             expect(pipe.transform(emitter)).toBeUndefined();
         });
 
-        it("should return the Derivable itself when it has a value", () => {
-            emitter.set("hello");
+        it('should return the Derivable itself when it has a value', () => {
+            emitter.set('hello');
             const result = pipe.transform(emitter);
             expect(result).toBe(emitter);
-            expect((result as DerivableAtom<any>).get()).toBe("hello");
+            expect((result as DerivableAtom<any>).get()).toBe('hello');
         });
 
-        it("should return the DerivableProxy itself", () => {
-            emitter.set({ prop: "proxy value" });
+        it('should return the DerivableProxy itself', () => {
+            emitter.set({ prop: 'proxy value' });
             const result = pipe.transform(proxy);
-            expect(result!.$value).toEqual({ prop: "proxy value" });
-            expect((result as any).$value.prop).toBe("proxy value");
+            expect(result!.$value).toEqual({ prop: 'proxy value' });
+            expect(result!.prop.$value).toBe('proxy value');
         });
 
-        it("should dispose the previous subscription when a new derivable is passed", () => {
+        it('should dispose the previous subscription when a new derivable is passed', () => {
             pipe.transform(emitter);
             expect(getObservers(emitter).length).toBe(1);
 
@@ -48,21 +48,21 @@ describe("ValueForPipe", () => {
             expect(getObservers(newEmitter).length).toBe(1);
         });
 
-        it("should call markForCheck when derivable updates", () => {
+        it('should call markForCheck when derivable updates', () => {
             pipe.transform(emitter);
 
-            emitter.set("new value");
+            emitter.set('new value');
 
             expect(cdr.markForCheck).toHaveBeenCalled();
         });
     });
 
-    describe("#ngOnDestroy", () => {
-        it("should not throw when no subscription exists", () => {
+    describe('#ngOnDestroy', () => {
+        it('should not throw when no subscription exists', () => {
             expect(() => pipe.ngOnDestroy()).not.toThrow();
         });
 
-        it("should unsubscribe from the derivable", () => {
+        it('should unsubscribe from the derivable', () => {
             pipe.transform(emitter);
             expect(getObservers(emitter).length).toBe(1);
 

--- a/projects/politie/ngx-sherlock/src/lib/value-for.pipe.spec.ts
+++ b/projects/politie/ngx-sherlock/src/lib/value-for.pipe.spec.ts
@@ -1,0 +1,74 @@
+import { ChangeDetectorRef } from "@angular/core";
+import { atom, DerivableAtom } from "@politie/sherlock";
+import { ProxyDescriptor } from "@politie/sherlock-proxy";
+import { getObservers } from "./utils.spec";
+import { ValueForPipe } from "./value-for.pipe";
+
+describe("ValueForPipe", () => {
+    let cdr: jasmine.SpyObj<ChangeDetectorRef>;
+    let pipe: ValueForPipe<any>;
+    let emitter: DerivableAtom<any>;
+    let proxy: any;
+
+    beforeEach(() => {
+        cdr = jasmine.createSpyObj("ChangeDetectorRef", ["markForCheck"]);
+        pipe = new ValueForPipe(cdr);
+
+        emitter = atom.unresolved();
+        proxy = new ProxyDescriptor().$create(emitter);
+    });
+
+    describe("#transform", () => {
+        it("should return undefined for unresolved Derivable", () => {
+            expect(pipe.transform(emitter)).toBeUndefined();
+        });
+
+        it("should return the Derivable itself when it has a value", () => {
+            emitter.set("hello");
+            const result = pipe.transform(emitter);
+            expect(result).toBe(emitter);
+            expect((result as DerivableAtom<any>).get()).toBe("hello");
+        });
+
+        it("should return the DerivableProxy itself", () => {
+            emitter.set({ prop: "proxy value" });
+            const result = pipe.transform(proxy);
+            expect(result!.$value).toEqual({ prop: "proxy value" });
+            expect((result as any).$value.prop).toBe("proxy value");
+        });
+
+        it("should dispose the previous subscription when a new derivable is passed", () => {
+            pipe.transform(emitter);
+            expect(getObservers(emitter).length).toBe(1);
+
+            const newEmitter = atom.unresolved();
+            pipe.transform(newEmitter);
+
+            expect(getObservers(emitter).length).toBe(0);
+            expect(getObservers(newEmitter).length).toBe(1);
+        });
+
+        it("should call markForCheck when derivable updates", () => {
+            pipe.transform(emitter);
+
+            emitter.set("new value");
+
+            expect(cdr.markForCheck).toHaveBeenCalled();
+        });
+    });
+
+    describe("#ngOnDestroy", () => {
+        it("should not throw when no subscription exists", () => {
+            expect(() => pipe.ngOnDestroy()).not.toThrow();
+        });
+
+        it("should unsubscribe from the derivable", () => {
+            pipe.transform(emitter);
+            expect(getObservers(emitter).length).toBe(1);
+
+            pipe.ngOnDestroy();
+
+            expect(getObservers(emitter).length).toBe(0);
+        });
+    });
+});

--- a/projects/politie/ngx-sherlock/src/lib/value-for.pipe.ts
+++ b/projects/politie/ngx-sherlock/src/lib/value-for.pipe.ts
@@ -1,0 +1,77 @@
+import {
+    ChangeDetectorRef,
+    OnDestroy,
+    Pipe,
+    PipeTransform,
+} from "@angular/core";
+import { Derivable, isDerivable, unresolved } from "@politie/sherlock";
+import { DerivableProxy, isDerivableProxy } from "@politie/sherlock-proxy";
+
+/**
+ * The {@link ValueForPipe} is designed to be used inside Angular's
+ * `@for` loops. It keeps a `Derivable` or `DerivableProxy` in sync with
+ * Angular's change detection without unwrapping the value directly.
+ *
+ * Unlike {@link ValuePipe}, this pipe **returns the derivable object itself**,
+ * so you can decide in the template how to extract the value (`.get()` or `$value`).
+ *
+ * Whenever the derivable updates, the `ChangeDetectorRef` of the `@Host()` component
+ * will be `markedForCheck` to ensure the loop items re-render correctly.
+ *
+ * ## Example usage
+ *
+ * ```html
+ * <!-- Example with Derivable in a for loop -->
+ * @for (item of items$ | valueFor; track item) {
+ *   <li>{{ item.get() }}</li>
+ * }
+ *
+ * <!-- Example with DerivableProxy -->
+ * @for (user of users$ | valueFor; track user) {
+ *   <li>{{ user.$value?.name }}</li>
+ * }
+ * ```
+ */
+@Pipe({ name: "valueFor", pure: false })
+export class ValueForPipe<T> implements PipeTransform, OnDestroy {
+    #current?: Derivable<T> | DerivableProxy<T>;
+    #unsubscribe?: () => void;
+
+    constructor(private readonly cdr: ChangeDetectorRef) {}
+
+    transform<D extends Derivable<T> | DerivableProxy<T>>(
+        derivable: D
+    ): D | undefined {
+        if (this.#current && this.#current !== derivable) {
+            this.ngOnDestroy();
+        }
+
+        if (!this.#current) {
+            this.#subscribe(derivable);
+            this.#current = derivable;
+        }
+
+        if (
+            isDerivable(this.#current) &&
+            this.#current.getState() === unresolved
+        ) {
+            return undefined;
+        }
+
+        return this.#current as D;
+    }
+
+    ngOnDestroy(): void {
+        this.#unsubscribe?.();
+        this.#unsubscribe = undefined;
+        this.#current = undefined;
+    }
+
+    #subscribe(derivable: Derivable<T> | DerivableProxy<T>) {
+        if (isDerivable(derivable)) {
+            this.#unsubscribe = derivable.react(() => this.cdr.markForCheck());
+        } else if (isDerivableProxy(derivable)) {
+            this.#unsubscribe = derivable.$react(() => this.cdr.markForCheck());
+        }
+    }
+}

--- a/projects/politie/ngx-sherlock/src/lib/value-for.pipe.ts
+++ b/projects/politie/ngx-sherlock/src/lib/value-for.pipe.ts
@@ -3,9 +3,9 @@ import {
     OnDestroy,
     Pipe,
     PipeTransform,
-} from "@angular/core";
-import { Derivable, isDerivable, unresolved } from "@politie/sherlock";
-import { DerivableProxy, isDerivableProxy } from "@politie/sherlock-proxy";
+} from '@angular/core';
+import { Derivable, isDerivable, unresolved } from '@politie/sherlock';
+import { DerivableProxy, isDerivableProxy } from '@politie/sherlock-proxy';
 
 /**
  * The {@link ValueForPipe} is designed to be used inside Angular's
@@ -16,7 +16,7 @@ import { DerivableProxy, isDerivableProxy } from "@politie/sherlock-proxy";
  * so you can decide in the template how to extract the value (`.get()` or `$value`).
  *
  * Whenever the derivable updates, the `ChangeDetectorRef` of the `@Host()` component
- * will be `markedForCheck` to ensure the loop items re-render correctly.
+ * will be `markForCheck` to ensure the loop items re-render correctly.
  *
  * ## Example usage
  *
@@ -32,7 +32,7 @@ import { DerivableProxy, isDerivableProxy } from "@politie/sherlock-proxy";
  * }
  * ```
  */
-@Pipe({ name: "valueFor", pure: false })
+@Pipe({ name: 'valueFor', pure: false })
 export class ValueForPipe<T> implements PipeTransform, OnDestroy {
     #current?: Derivable<T> | DerivableProxy<T>;
     #unsubscribe?: () => void;


### PR DESCRIPTION
- Introduces ValueForPipe to unwrap Derivable and DerivableProxy objects inside Angular @for loops without unwrapping values immediately.
- Returns the derivable object itself, allowing templates to call .get() or $value.
- Supports change detection and unsubscribes automatically on derivable changes.
- Fully unit-testable via constructor-injected ChangeDetectorRef.